### PR TITLE
[feat] add `keep_terminal` flag to support keeping terminal observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ env = GymnaxToStoa(gymnax_env, env_params)
 
 # 3. Apply standard wrappers
 # Note: The order of wrappers matters.
-env = AutoResetWrapper(env, next_obs_in_extras=True)
+env = AutoResetWrapper(env, keep_terminal=False)
 env = RecordEpisodeMetrics(env)
 
 # JIT compile the reset and step functions for performance


### PR DESCRIPTION
See discussion in EdanToledo/Stoix#181. The issue is basically how to handle episode boundaries. Suppose `base_env.step` enters a state with `timestep.done() == True` (either terminated or truncated). So the question is what an auto-reset wrapper should return:

1. Return the _state and observation_ from `base_env.reset` and keep the other timestep properties from `base_env.step`. For proper bootstrapping in algorithms, though, this requires doubling the number of critic evaluations.
2. Just return everything from `base_env.step` and return `base_env.reset`, with a dummy reward and discount, on the next call to `wrapped_env.step`. This might require masking out any losses computed based on the policy's actions in the final state.

Both of these are valid choices and we should enable the user to decide which they prefer. For example, in settings where evaluating the critic involves some form of search, option two would incur half the number of critic invocations as option one.

This PR also fixes #5 by re-implementing the optimistic auto reset wrapper.